### PR TITLE
chore: add workflow_dispatch to release workflow for manual republish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish (e.g. v1.3.3)"
+        required: true
 
 concurrency:
   group: release-please
@@ -37,13 +42,13 @@ jobs:
     permissions:
       contents: read
     needs: release-please
-    if: needs.release-please.outputs.release_created
+    if: needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.release-please.outputs.release_tag }}
+          ref: ${{ needs.release-please.outputs.release_tag || inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger with a `tag` input to the release workflow
- Allows manually re-publishing an existing release tag when the automated pipeline fails

## Why

v1.3.3 failed to publish because the pypi-publish action was pinned to a commit SHA with no Docker image. The fix is on main (#107) but re-running the old workflow replays the broken YAML. This dispatch trigger lets us run the *current* workflow against the v1.3.3 tag.

## After merge

Run from the Actions tab: `release-please` > `Run workflow` > tag: `v1.3.3`