### PR TITLE
chore: fix download-artifact in publish-testpypi missing name and path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,6 +81,9 @@ jobs:
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: python-package-distributions
+          path: dist/
 
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Add missing `name` and `path` to the `download-artifact` step in `publish-testpypi`

## Why

The `publish-testpypi` job was missing `name: python-package-distributions` and `path: dist/` on its download-artifact step. Without these, the artifact lands in a subdirectory instead of `dist/`, causing `pypa/gh-action-pypi-publish` to fail with `FileNotFoundError: No such file or directory: '/github/workspace/dist'`.

The `publish-pypi` job already had these set correctly.