### PR TITLE
fix: copy_object date range metadata copying

### DIFF
--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -1530,6 +1530,22 @@ class PlexosDB:
                 JOIN temp_data_mapping tdm ON b.data_id = tdm.old_id
             """)
 
+            # Copy date_from
+            self._db.execute("""
+                INSERT INTO t_date_from (data_id, date, state)
+                SELECT tdm.new_id, df.date, df.state
+                FROM t_date_from df
+                JOIN temp_data_mapping tdm ON df.data_id = tdm.old_id
+            """)
+
+            # Copy date_to
+            self._db.execute("""
+                INSERT INTO t_date_to (data_id, date, state)
+                SELECT tdm.new_id, dt.date, dt.state
+                FROM t_date_to dt
+                JOIN temp_data_mapping tdm ON dt.data_id = tdm.old_id
+            """)
+
             self._db.execute("DROP TABLE IF EXISTS temp_mapping")
             self._db.execute("DROP TABLE IF EXISTS temp_data_mapping")
         return True

--- a/tests/test_plexosdb_copy_object.py
+++ b/tests/test_plexosdb_copy_object.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -38,6 +39,52 @@ def test_copy_object(db_base: PlexosDB, caplog):
             assert new_properties[old_property] != original_object_id
         else:
             assert old_properties[old_property] == new_properties[old_property]
+
+
+def test_copy_object_copies_date_from_and_date_to(db_base: PlexosDB):
+    from plexosdb import ClassEnum
+
+    db = db_base
+    original_object_name = "TestGenDates"
+    object_class = ClassEnum.Generator
+    db.add_object(object_class, original_object_name)
+
+    date_from = datetime(2026, 1, 1)
+    date_to = datetime(2026, 12, 31)
+    original_data_id = db.add_property(
+        ClassEnum.Generator,
+        original_object_name,
+        "Max Capacity",
+        100.0,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+    original_date_from = db.query(
+        "SELECT date FROM t_date_from WHERE data_id = ?", (original_data_id,)
+    )
+    original_date_to = db.query(
+        "SELECT date FROM t_date_to WHERE data_id = ?", (original_data_id,)
+    )
+    assert original_date_from == [(date_from.isoformat(),)]
+    assert original_date_to == [(date_to.isoformat(),)]
+
+    new_object_name = "TestGenDatesCopy"
+    db.copy_object(object_class, original_object_name, new_object_name)
+
+    new_data_ids = db.get_object_data_ids(object_class, name=new_object_name)
+    assert len(new_data_ids) == 1
+    new_data_id = new_data_ids[0]
+    assert new_data_id != original_data_id
+
+    copied_date_from = db.query(
+        "SELECT date FROM t_date_from WHERE data_id = ?", (new_data_id,)
+    )
+    copied_date_to = db.query(
+        "SELECT date FROM t_date_to WHERE data_id = ?", (new_data_id,)
+    )
+    assert copied_date_from == [(date_from.isoformat(),)]
+    assert copied_date_to == [(date_to.isoformat(),)]
 
 
 def test_copy_object_with_memberships(db_base: PlexosDB):


### PR DESCRIPTION
Reopens #139  
Resolves #138

## Summary

This pull request reapplies the changes from #139 to address #138. It improves the object-copying logic so that date-bound property values are preserved when objects are duplicated.

Previously, `date_from` and `date_to` values associated with object properties were not copied to the newly created object. This could result in copied objects losing important temporal property metadata.

## Changes

### Object property copying

- Updated `_copy_object_properties` in `src/plexosdb/db.py` to explicitly copy `date_from` and `date_to` values when duplicating object properties.
- Ensures that copied objects retain the same effective date ranges as the source object.

### Tests

- Added `test_copy_object_copies_date_from_and_date_to` in `tests/test_plexosdb_copy_object.py`.
- Verifies that `date_from` and `date_to` are preserved when copying an object.
- Added the required `datetime` import to support the new test case.

## Notes

This PR replaces the previous attempt in #139 after the changes were reapplied cleanly.